### PR TITLE
Avoid swallowing errors

### DIFF
--- a/lib/rack/healthcheck/middleware.rb
+++ b/lib/rack/healthcheck/middleware.rb
@@ -11,12 +11,14 @@ module Rack
       end
 
       def call(env)
-        path = env["PATH_INFO"]
-        request_method = env["REQUEST_METHOD"]
+        begin
+          path = env["PATH_INFO"]
+          request_method = env["REQUEST_METHOD"]
 
-        action = Rack::Healthcheck::Action.get(path, request_method)
-        action.send(request_method.downcase)
-      rescue Rack::Healthcheck::Action::InvalidAction, Rack::Healthcheck::Actions::Base::InvalidRequestMethod
+          action = Rack::Healthcheck::Action.get(path, request_method)
+          return action.send(request_method.downcase)
+        rescue Rack::Healthcheck::Action::InvalidAction, Rack::Healthcheck::Actions::Base::InvalidRequestMethod
+        end
         @app.call(env)
       end
     end


### PR DESCRIPTION
Wrap in begin..end, so we do NOT assign
Rack::Healthcheck::Action::InvalidAction to $!

This is an attempt at removing these unhelpful errors from Rollbar errors page:
![Screenshot 2023-12-19 at 12 28 01](https://github.com/skcc321/rack-healthcheck/assets/9031589/4e9e3609-a534-4c25-aae7-fdb4c33f387e)

Reference: https://stackoverflow.com/questions/27852672/27854841
